### PR TITLE
Remove example projects from readme

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,9 @@ jobs:
             fetch-depth: 0
         - name: asdf_install
           uses: asdf-vm/actions/install@v1
+          with:
+            tool_versions: |
+              nodejs 20.14.0
         - name: "linting: ${{ matrix.files }}"
           run: npx -y awesome-lint ${{ matrix.files }}
     awesome-bot:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The list is a work in progress, please feel invited to [contribute](#contributin
 - [django-cms](https://docs.django-cms.org/) - django-cms's developer documentation is as extensive as it's well-organized. It uses the Furo theme. **#sphinx** **#large-project**.
 - [Ray](https://docs.ray.io/) - Ray is a documentation project spanning multiple software components. It uses several extensions from the Executable Book project. Features are showcased in [this twitter thread](https://twitter.com/readthedocs/status/1663923671470047234). **#sphinx** **#themes** **#large-project**.
 - [Scrapy](https://docs.scrapy.org/) - Embeds a lot of reference snippets and uses `sphinx-hoverxref` for quick reference tooltips. Lots of inspiration to be found in content organization. **#sphinx**.
-- [setuptools](https://setuptools.pypa.io/) - Lots of features, using the Furo theme. **#sphinx** **#themes**.
+- [setuptools](https://setuptools.pypa.io/) - Lots of features, using the Furo theme. [Twitter thread](https://twitter.com/readthedocs/status/1546527820150718469) with some examples. **#sphinx** **#themes**.
 - [sphinx-needs](https://sphinx-needs.readthedocs.io/) - Documentation of `sphinx-needs`. **#sphinx** **#themes**.
 - [sphinx-immaterial](https://sphinx-immaterial.readthedocs.io/) - Documentation of `sphinx-immaterial`, a Material theme for Sphinx, based on Material for MkDocs. **#sphinx** **#themes**.
 - [Uberspace](https://manual.uberspace.de/) - Customized sidebar and footer, adding project's branding through custom CSS and HTML to `sphinx_rtd_theme`. Latest version and release date on front page. **#sphinx** **#themes** **#custom-theme**.

--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ The list is a work in progress, please feel invited to [contribute](#contributin
 
 <!-- END CONTENT -->
 
-## Example projects
-
-- [Basic Sphinx example](https://github.com/readthedocs-examples/example-sphinx-basic) - Basic example of using Sphinx on Read the Docs. **#sphinx**.
-- [Basic MkDocs example](https://github.com/readthedocs-examples/example-mkdocs-basic) - Basic example of using MkDocs on Read the Docs. **#mkdocs**.
-- [Jupyter Book example](https://github.com/readthedocs-examples/example-jupyter-book) - Using Jupyter Book on Read the Docs with popular extensions. **#jupyter-notebook** **#sphinx**.
-
 ## Tag cloud
 
 The categories in this list are intersecting at the following tags:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The list is a work in progress, please feel invited to [contribute](#contributin
 - [MkDocs projects](#mkdocs-projects)
 - [API Reference](#api-reference)
 - [Science projects](#science-projects)
-- [Example projects](#example-projects)
 - [Tag cloud](#tag-cloud)
 
 <!-- CONTENT -->

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The list is a work in progress, please feel invited to [contribute](#contributin
 - [django-cms](https://docs.django-cms.org/) - django-cms's developer documentation is as extensive as it's well-organized. It uses the Furo theme. **#sphinx** **#large-project**.
 - [Ray](https://docs.ray.io/) - Ray is a documentation project spanning multiple software components. It uses several extensions from the Executable Book project. Features are showcased in [this twitter thread](https://twitter.com/readthedocs/status/1663923671470047234). **#sphinx** **#themes** **#large-project**.
 - [Scrapy](https://docs.scrapy.org/) - Embeds a lot of reference snippets and uses `sphinx-hoverxref` for quick reference tooltips. Lots of inspiration to be found in content organization. **#sphinx**.
-- [setuptools](https://setuptools.pypa.io/) - Lots of features, using the Furo theme. [Twitter thread](https://twitter.com/readthedocs/status/1546527820150718469) with some examples. **#sphinx** **#themes**.
+- [setuptools](https://setuptools.pypa.io/) - Lots of features, using the Furo theme. **#sphinx** **#themes**.
 - [sphinx-needs](https://sphinx-needs.readthedocs.io/) - Documentation of `sphinx-needs`. **#sphinx** **#themes**.
 - [sphinx-immaterial](https://sphinx-immaterial.readthedocs.io/) - Documentation of `sphinx-immaterial`, a Material theme for Sphinx, based on Material for MkDocs. **#sphinx** **#themes**.
 - [Uberspace](https://manual.uberspace.de/) - Customized sidebar and footer, adding project's branding through custom CSS and HTML to `sphinx_rtd_theme`. Latest version and release date on front page. **#sphinx** **#themes** **#custom-theme**.


### PR DESCRIPTION
I'm removing the "Example projects" list from the readme since we don't need to maintain that list in two separate places. We are already doing this in https://docs.readthedocs.io/en/stable/examples.html where we added Antora and this readme was not updated.